### PR TITLE
Add pre-commit docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0
+      - name: Run tests
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+.venv/
+
+# Local env
+.env
+
+# Build artifacts
+dist/
+*.egg-info/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.0
+    hooks:
+      - id: ruff

--- a/README.md
+++ b/README.md
@@ -2,3 +2,29 @@
 Convert Egglog-style rewrite rules into formal inference rules, output as LaTeX.
 This package provides a tiny parser for simple rewrite files and a CLI that
 emits a LaTeX representation of those rules.
+
+## Development
+
+This project uses `pre-commit` to run formatting and linting checks. After
+installing the development dependencies with `pip install -e .[dev]`, install the
+git hooks:
+
+```bash
+pre-commit install
+```
+
+`pre-commit` uses Black and Ruff as defined in `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.0
+    hooks:
+      - id: ruff
+```
+
+The CI workflow will run the same checks and the test suite using `pytest`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,24 @@ authors = [{ name = "Swapnil Patel" }]
 license = { file = "LICENSE" }
 requires-python = ">=3.8"
 
+[project.optional-dependencies]
+dev = [
+    "pre-commit",
+    "ruff",
+    "black",
+    "pytest",
+]
+
 [project.scripts]
 eggtx = "eggtx.__main__:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.black]
+line-length = 88
+target-version = ['py38']
+
+[tool.ruff]
+line-length = 88
+target-version = "py38"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["config:base"],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- document Black and Ruff pre-commit config in README

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml .github/workflows/ci.yml pyproject.toml renovate.json .gitignore` *(fails: command not found)*
- `pytest -q`
